### PR TITLE
fixed config regeneration

### DIFF
--- a/tasks/clients.yml
+++ b/tasks/clients.yml
@@ -15,6 +15,8 @@
     server_public_key: "{{ _pubkey_value['content'] | b64decode }}"
     preshared_key: "{{ _pskkey_value['content'] | b64decode }}"
   loop: "{{ peers | list }}"
+  notify:
+    - restart systemd-networkd
 
 - name: Copy client configs
   shell: cp -u $(grep -iRl '{{ item.publickey }}' {{ wireguard_clients_dir }}/) /tmp/{{ item.name }}.conf


### PR DESCRIPTION
when client configs were generated they were not loaded - while `/etc/systemd/network/wg0.netdev` held new configuration, `wg showconf wg0` would still show old configuration. this commit adds service restart to load new config.